### PR TITLE
Add support for fields in message queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ s.on('data', function (d) {
 })
 ```
 
+
+```
+// Optionally request the fields you want (for performance)
+// https://developers.google.com/gmail/api/guides/performance
+
+var Gmail = require('node-gmail-api')
+  , gmail = new Gmail(<KEY>)
+  , s = gmail.messages('label:inbox', { fields: ['id', 'internalDate', 'labelIds', 'payload']})
+
+s.on('data', function (d) {
+  console.log(d.id)
+})
+```
+
 License
 =======
 ISC

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var request = require('request')
   , multiparty = require('multiparty')
   , ss = require('stream-stream')
   , through = require('through2')
+  , querystring = require('querystring')
   , api = 'https://www.googleapis.com'
 
 var Gmail = function (key) {
@@ -55,6 +56,8 @@ var retrieve = function (key, q, endpoint, opts) {
       }
     }
 
+    var fields = opts.fields ? '?' + querystring.stringify({ fields: opts.fields.join(',')}) : ''
+
     if (page) reqOpts.qs.pageToken = page
     request(reqOpts, function (err, response, body) {
       if (err) {
@@ -71,10 +74,6 @@ var retrieve = function (key, q, endpoint, opts) {
         return result.end()
       }
       var messages = body[endpoint].map(function (m) {
-        var fields = '';
-        if(opts.fields) {
-          fields = '?' + querystring.stringify({ fields: opts.fields.join(',')});
-        }
         return {
           'Content-Type': 'application/http',
           body: 'GET ' + api + '/gmail/v1/users/me/' + endpoint + '/' + m.id + fields + '\n'

--- a/index.js
+++ b/index.js
@@ -71,9 +71,13 @@ var retrieve = function (key, q, endpoint, opts) {
         return result.end()
       }
       var messages = body[endpoint].map(function (m) {
+        var fields = '';
+        if(opts.fields) {
+          fields = '?' + querystring.stringify({ fields: opts.fields.join(',')});
+        }
         return {
           'Content-Type': 'application/http',
-          body: 'GET ' + api + '/gmail/v1/users/me/' + endpoint + '/' + m.id + '\n'
+          body: 'GET ' + api + '/gmail/v1/users/me/' + endpoint + '/' + m.id + fields + '\n'
         }
       })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-gmail-api",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Interacts with the gmail api, fetching emails",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi,

This is my first pull request so any advice would be great!

This pull request adds 'optional' user specified 'fields; support (like max). Aka Google only responds with the fields you require, saving bandwidth etc. See https://developers.google.com/gmail/api/guides/performance for more info.

I have attempted to gzip the batch request, as Google suggests this can also provide a performance improvement. However just adding the headers they suggest doesn't work and my understanding of multipart doesn't extend to decode the gzipped response. 

Thanks for a great module.

Dan