### PR TITLE
Bugfix, stop looping api pages when not required with max field supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ var retrieve = function (key, q, endpoint, opts) {
     , combined = ss()
     , opts = opts || {}
     , i = opts.max
+    , partsFound = 0
 
   var loop = function(page) {
     var reqOpts = {
@@ -103,10 +104,11 @@ var retrieve = function (key, q, endpoint, opts) {
 
         res.headers['content-type'] = type.replace('multipart/mixed', 'multipart/related')
         form.on('part', function (part) {
+          partsFound++;
           combined.write(part.pipe(split('\r\n')).pipe(new Parser))
         }).parse(res)
         form.on('close', function () {
-          if (body.nextPageToken) return loop(body.nextPageToken)
+          if (opts.max !== partsFound && body.nextPageToken) return loop(body.nextPageToken)
           combined.end()
         })
 


### PR DESCRIPTION
The documented example highlights the bug I discovered, (example copied below) which asks for all messages with the label inbox and return only 10 messages.

var Gmail = require('node-gmail-api')
  , gmail = new Gmail(<KEY>)
  , s = gmail.messages('label:inbox', {max: 10})
 
s.on('data', function (d) {
  console.log(d.snippet)
})

Which it does. However, when it finds a 'close' event, it will check if you have any more pages aka another nextPageToken. If another nextPageToken IS present it will request that page regardless of whether we have already retrieved the number of messages we need (max).

I had not noticed this until I had made the request against a user who had thousands of messages in their inbox (and thus pages) and it took ages to fire the "end" event when all I wanted was 1 result.

Should be a nice performance improvement and save on the API requests/bandwidth too.

There might be a better way to fix the bug (I looked at the issue very quickly).

Thanks

Dan


