### PR TITLE
max options should be used with maxResults query parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,8 @@ var retrieve = function (key, q, endpoint, opts) {
       json: true,
       timeout: opts.timeout,
       qs: {
-        q: q
+        q: q,
+        maxResults: i < 100 ? i : 100
       },
       headers: {
         'Authorization': 'Bearer ' + key
@@ -95,8 +96,6 @@ var retrieve = function (key, q, endpoint, opts) {
           body: 'GET ' + api + '/gmail/v1/users/me/' + endpoint + '/' + m.id + query + '\n'
         }
       })
-
-      messages.length = i < 100 ? i : 100
 
       var r = request({
         method: 'POST',


### PR DESCRIPTION
Gmail API has a `maxResults` query param that I believe `opts.max` is trying to fulfill.

Reference: https://developers.google.com/gmail/api/v1/reference/users/messages/list