### PR TITLE
replace deprecated batch endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ var retrieve = function (key, q, endpoint, opts) {
 
       var r = request({
         method: 'POST',
-        url: api + '/batch',
+        url: api + '/batch/gmail/v1',
         multipart: messages,
         timeout: opts.timeout,
         headers: {

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ var retrieve = function (key, q, endpoint, opts) {
 }
 
 /*
- * Feteches the number of estimated messages matching the query
+ * Fetches the number of estimated messages matching the query
  * Invokes callback with err and estimated number
  */
 Gmail.prototype.estimatedMessages = function (q, opts, next) {
@@ -162,7 +162,7 @@ Gmail.prototype.messages = function (q, opts) {
 }
 
 /*
- * Feteches the number of estimated threads matching the query
+ * Fetches the number of estimated threads matching the query
  * Invokes callback with err and estimated number
  */
 Gmail.prototype.estimatedThreads = function (q, opts, next) {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -36,7 +36,7 @@ test('retrieves threads', function (t) {
     .replyWithFile(200, __dirname + '/initial.json')
 
   nock('https://www.googleapis.com')
-    .post('/batch')
+    .post('/batch/gmail/v1')
     .replyWithFile(200, __dirname + '/batched.json', {
       'content-type': 'multipart/mixed; boundary=batch_FmDEX85qSFQ=_AAlNL3-GN3E='
     })


### PR DESCRIPTION
`node-gmail-API` currently fails as google returns a `404` response on requests to the `batch` endpoint:

```
{
  "statusCode": 404,
  "headers": {
    "content-length": "1449",
    "content-type": "text/html; charset=utf-8",
    "x-content-type-options": "nosniff",
    "x-frame-options": "SAMEORIGIN",
    "x-xss-protection": "0",
    "date": "Mon, 05 Oct 2020 08:41:22 GMT",
    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-27=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
    "connection": "close"
  },
  "request": {
    "uri": {
      "protocol": "https:",
      "slashes": true,
      "auth": null,
      "host": "www.googleapis.com",
      "port": 443,
      "hostname": "www.googleapis.com",
      "hash": null,
      "search": null,
      "query": null,
      "pathname": "/batch",
      "path": "/batch",
      "href": "https://www.googleapis.com/batch"
    },
    "method": "POST",
    "headers": {
      "Authorization": "Bearer [redacted]",
      "content-length": 11953
    }
  }
}
```

This causes the following crash, reported in #40:

```
events.js:187
      throw er; // Unhandled 'error' event
      ^

Error: unrecognized content-type: text/html; charset=utf-8
    at Form.parse (/home/user/development/app/node_modules/multiparty/index.js:159:21)
    at Request.<anonymous> (/home/user/development/app/node_modules/node-gmail-api/index.js:123:12)
    at Request.emit (events.js:210:5)
    at Request.onRequestResponse (/home/user/development/app/node_modules/request/request.js:1066:10)
```


[This comment](https://github.com/googleapis/google-api-dotnet-client/issues/1622#issuecomment-674753691) points to the cause of the problem: batch endpoint is deprecated and replaced by `batch/gmail/v1` in our case.

This pull request adapts the code accordingly. Tests are failing for a separate reason and are not fixed in this pull request.